### PR TITLE
fix: enable fan control on M4/M5 in system mode

### DIFF
--- a/tools/smc-helper/Makefile
+++ b/tools/smc-helper/Makefile
@@ -1,5 +1,5 @@
 CC = clang
-CFLAGS = -Wall -O2 -framework IOKit -framework CoreFoundation
+CFLAGS = -Wall -O2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -framework IOKit -framework CoreFoundation
 TARGET = smc-helper
 
 all: $(TARGET)
@@ -11,6 +11,6 @@ clean:
 	rm -f $(TARGET)
 
 install: $(TARGET)
-	cp $(TARGET) ../../fan/
+	cp $(TARGET) ../../fan/Resources/
 
 .PHONY: all clean install

--- a/tools/smc-helper/smc.c
+++ b/tools/smc-helper/smc.c
@@ -238,29 +238,55 @@ int getFanCount(io_connect_t conn)
     return (int)_strtoul((char *)val.bytes, val.dataSize, 10);
 }
 
+// Reject out-of-range fan indices before any "F%d..." key is formatted. This
+// runs as root via a NOPASSWD sudoers rule, so an unbounded fanNum would let a
+// caller overflow the small key buffers below; bound it to the real fan count.
+static int validFan(int fanNum, io_connect_t conn)
+{
+    if (fanNum < 0)
+        return 0;
+    int n = getFanCount(conn);
+    if (n <= 0)
+        return fanNum < 8; // SMC count unreadable: allow only a small sane range
+    return fanNum < n;
+}
+
 float getFanSpeed(int fanNum, io_connect_t conn)
 {
     SMCVal_t val;
-    char key[5];
-    sprintf(key, "F%dAc", fanNum);
-    
+    char key[8];
+    snprintf(key, sizeof key, "F%dAc", fanNum);
+
     kern_return_t result = SMCReadKey(key, &val, conn);
     if (result != kIOReturnSuccess)
         return -1;
-    
+
     return getFloatFromVal(val);
 }
 
 float getFanMinSpeed(int fanNum, io_connect_t conn)
 {
     SMCVal_t val;
-    char key[5];
-    sprintf(key, "F%dMn", fanNum);
-    
+    char key[8];
+    snprintf(key, sizeof key, "F%dMn", fanNum);
+
     kern_return_t result = SMCReadKey(key, &val, conn);
     if (result != kIOReturnSuccess)
         return -1;
-    
+
+    return getFloatFromVal(val);
+}
+
+float getFanMaxSpeed(int fanNum, io_connect_t conn)
+{
+    SMCVal_t val;
+    char key[8];
+    snprintf(key, sizeof key, "F%dMx", fanNum);
+
+    kern_return_t result = SMCReadKey(key, &val, conn);
+    if (result != kIOReturnSuccess)
+        return -1;
+
     return getFloatFromVal(val);
 }
 
@@ -417,7 +443,15 @@ kern_return_t setFanMode(int fanNum, int mode, io_connect_t conn)
 kern_return_t setFanSpeed(int fanNum, int speed, io_connect_t conn)
 {
     SMCVal_t val;
-    char key[5];
+    char key[8];
+
+    // Clamp to the fan's own reported envelope so a bad caller can't push a
+    // nonsense target through the root helper. F{n}Mx is the hardware ceiling.
+    if (speed < 0)
+        speed = 0;
+    float fmax = getFanMaxSpeed(fanNum, conn);
+    if (fmax > 0 && speed > (int)fmax)
+        speed = (int)fmax;
 
     // Take manual control. Direct mode=1 works from AUTO; if the firmware holds
     // SYSTEM mode (0x82) it falls back to the Ftst force-test unlock.
@@ -428,7 +462,7 @@ kern_return_t setFanSpeed(int fanNum, int speed, io_connect_t conn)
     }
 
     // Then set target speed using F{n}Tg
-    sprintf(key, "F%dTg", fanNum);
+    snprintf(key, sizeof key, "F%dTg", fanNum);
     
     kern_return_t result = SMCReadKey(key, &val, conn);
     if (result != kIOReturnSuccess)
@@ -480,100 +514,33 @@ void printFanInfo(io_connect_t conn)
     for (int i = 0; i < numFans; i++)
     {
         SMCVal_t val;
-        char key[5];
-        
+        char key[8];
+
         printf("\nFan #%d:\n", i);
-        
+
         // Current speed
         printf("  Current speed: %.0f RPM\n", getFanSpeed(i, conn));
-        
+
         // Min speed
-        sprintf(key, "F%dMn", i);
+        snprintf(key, sizeof key, "F%dMn", i);
         if (SMCReadKey(key, &val, conn) == kIOReturnSuccess)
         {
             printf("  Min speed: %.0f RPM (type: %s)\n", getFloatFromVal(val), val.dataType);
         }
-        
+
         // Max speed
-        sprintf(key, "F%dMx", i);
+        snprintf(key, sizeof key, "F%dMx", i);
         if (SMCReadKey(key, &val, conn) == kIOReturnSuccess)
         {
             printf("  Max speed: %.0f RPM\n", getFloatFromVal(val));
         }
-        
+
         // Target speed
-        sprintf(key, "F%dTg", i);
+        snprintf(key, sizeof key, "F%dTg", i);
         if (SMCReadKey(key, &val, conn) == kIOReturnSuccess)
         {
             printf("  Target speed: %.0f RPM\n", getFloatFromVal(val));
         }
-    }
-}
-
-void readKey(const char *keyName, io_connect_t conn)
-{
-    SMCVal_t val;
-    char key[5];
-    strncpy(key, keyName, 4);
-    key[4] = '\0';
-    
-    kern_return_t result = SMCReadKey(key, &val, conn);
-    if (result != kIOReturnSuccess)
-    {
-        fprintf(stderr, "Error: Cannot read key %s: %08x\n", key, result);
-        return;
-    }
-    
-    printf("Key: %s\n", key);
-    printf("Type: %s\n", val.dataType);
-    printf("Size: %u\n", val.dataSize);
-    printf("Value: %.2f\n", getFloatFromVal(val));
-    
-    printf("Bytes: ");
-    for (UInt32 i = 0; i < val.dataSize; i++)
-    {
-        printf("%02x ", (unsigned char)val.bytes[i]);
-    }
-    printf("\n");
-}
-
-void writeKeyHex(const char *keyName, const char *hexValue, io_connect_t conn)
-{
-    SMCVal_t val;
-    char key[5];
-    strncpy(key, keyName, 4);
-    key[4] = '\0';
-    
-    // First read to get type and size
-    kern_return_t result = SMCReadKey(key, &val, conn);
-    if (result != kIOReturnSuccess)
-    {
-        fprintf(stderr, "Error: Cannot read key %s: %08x\n", key, result);
-        return;
-    }
-    
-    // Parse hex value
-    size_t hexLen = strlen(hexValue);
-    for (size_t i = 0; i < hexLen / 2 && i < val.dataSize; i++)
-    {
-        char c[3] = { hexValue[i * 2], hexValue[i * 2 + 1], '\0' };
-        val.bytes[i] = (unsigned char)strtol(c, NULL, 16);
-    }
-    
-    sprintf(val.key, "%s", key);
-    
-    result = SMCWriteKey(val, conn);
-    if (result != kIOReturnSuccess)
-    {
-        fprintf(stderr, "Error: Write failed: %08x\n", result);
-    }
-    else
-    {
-        printf("Success: Wrote to %s\n", key);
-        // Verify
-        SMCVal_t verify;
-        SMCReadKey(key, &verify, conn);
-        printf("New value: %.2f\n", getFloatFromVal(verify));
     }
 }
 
@@ -582,15 +549,12 @@ void usage(const char *prog)
     printf("SMC Fan Control Helper\n");
     printf("Usage:\n");
     printf("  %s info                     - Show fan information\n", prog);
-    printf("  %s read <KEY>               - Read SMC key\n", prog);
     printf("  %s set <FAN#> <RPM>         - Set fan target speed (forced mode)\n", prog);
     printf("  %s auto <FAN#>              - Set fan back to automatic mode\n", prog);
-    printf("  %s write <KEY> <HEXVALUE>   - Write raw hex to key\n", prog);
     printf("\n");
     printf("Examples:\n");
     printf("  %s set 0 3500               - Set fan 0 to 3500 RPM\n", prog);
     printf("  %s auto 0                   - Set fan 0 back to automatic\n", prog);
-    printf("  %s read F0Tg                - Read fan 0 target speed\n", prog);
 }
 
 int main(int argc, char *argv[])
@@ -616,16 +580,6 @@ int main(int argc, char *argv[])
     {
         printFanInfo(g_conn);
     }
-    else if (strcmp(cmd, "read") == 0)
-    {
-        if (argc < 3)
-        {
-            fprintf(stderr, "Error: specify key to read\n");
-            SMCClose(g_conn);
-            return 1;
-        }
-        readKey(argv[2], g_conn);
-    }
     else if (strcmp(cmd, "set") == 0)
     {
         if (argc < 4)
@@ -637,7 +591,14 @@ int main(int argc, char *argv[])
         }
         int fanNum = atoi(argv[2]);
         int speed = atoi(argv[3]);
-        
+
+        if (!validFan(fanNum, g_conn))
+        {
+            fprintf(stderr, "Error: fan %d out of range (have %d fans)\n", fanNum, getFanCount(g_conn));
+            SMCClose(g_conn);
+            return 1;
+        }
+
         printf("Setting fan %d to %d RPM (forced mode)...\n", fanNum, speed);
         result = setFanSpeed(fanNum, speed, g_conn);
         if (result == kIOReturnSuccess)
@@ -646,8 +607,8 @@ int main(int argc, char *argv[])
             // Verify
             float current = getFanSpeed(fanNum, g_conn);
             SMCVal_t val;
-            char key[5];
-            sprintf(key, "F%dTg", fanNum);
+            char key[8];
+            snprintf(key, sizeof key, "F%dTg", fanNum);
             SMCReadKey(key, &val, g_conn);
             printf("Target speed: %.0f RPM\n", getFloatFromVal(val));
             printf("Current speed: %.0f RPM\n", current);
@@ -673,7 +634,14 @@ int main(int argc, char *argv[])
             return 1;
         }
         int fanNum = atoi(argv[2]);
-        
+
+        if (!validFan(fanNum, g_conn))
+        {
+            fprintf(stderr, "Error: fan %d out of range (have %d fans)\n", fanNum, getFanCount(g_conn));
+            SMCClose(g_conn);
+            return 1;
+        }
+
         printf("Setting fan %d to automatic mode...\n", fanNum);
         result = setFanAuto(fanNum, g_conn);
         if (result == kIOReturnSuccess)
@@ -686,17 +654,6 @@ int main(int argc, char *argv[])
             SMCClose(g_conn);
             return 1;
         }
-    }
-    else if (strcmp(cmd, "write") == 0)
-    {
-        if (argc < 4)
-        {
-            fprintf(stderr, "Error: specify key and hex value\n");
-            fprintf(stderr, "Usage: %s write <KEY> <HEXVALUE>\n", argv[0]);
-            SMCClose(g_conn);
-            return 1;
-        }
-        writeKeyHex(argv[2], argv[3], g_conn);
     }
     else
     {

--- a/tools/smc-helper/smc.c
+++ b/tools/smc-helper/smc.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <IOKit/IOKitLib.h>
 #include "smc.h"
 
@@ -263,26 +264,153 @@ float getFanMinSpeed(int fanNum, io_connect_t conn)
     return getFloatFromVal(val);
 }
 
+// Mode-key casing varies by silicon: F%dMd (Intel/M1-M4), F%dmd (M5).
+// Probe once, cache the template.
+static const char *fanModeTemplate(io_connect_t conn)
+{
+    static char tmpl[8] = "";
+    if (tmpl[0] == '\0')
+    {
+        SMCKeyData_keyInfo_t ki;
+        if (SMCGetKeyInfo(_strtoul("F0Md", 4, 16), &ki, conn) == kIOReturnSuccess && ki.dataSize > 0)
+            strcpy(tmpl, "F%dMd");
+        else
+            strcpy(tmpl, "F%dmd");
+    }
+    return tmpl;
+}
+
+static void fanModeKey(char *buf, int fanNum, io_connect_t conn)
+{
+    sprintf(buf, fanModeTemplate(conn), fanNum);
+}
+
+// Whether this machine exposes the Ftst force-test key (absent on M5).
+static int ftstAvailable(io_connect_t conn)
+{
+    static int checked = 0, avail = 0;
+    if (!checked)
+    {
+        SMCKeyData_keyInfo_t ki;
+        avail = (SMCGetKeyInfo(_strtoul("Ftst", 4, 16), &ki, conn) == kIOReturnSuccess && ki.dataSize > 0);
+        checked = 1;
+    }
+    return avail;
+}
+
+static void writeFtst(int value, io_connect_t conn)
+{
+    SMCKeyData_keyInfo_t ki;
+    UInt32 key = _strtoul("Ftst", 4, 16);
+    if (SMCGetKeyInfo(key, &ki, conn) != kIOReturnSuccess || ki.dataSize < 1)
+        return;
+
+    SMCKeyData_t in, out;
+    memset(&in, 0, sizeof(in));
+    memset(&out, 0, sizeof(out));
+    in.key = key;
+    in.data8 = SMC_CMD_WRITE_BYTES;
+    in.keyInfo.dataSize = ki.dataSize;
+    in.bytes[0] = (UInt8)value;
+    SMCCall(KERNEL_INDEX_SMC, &in, &out, conn);
+}
+
+// Write the fan mode key and return the SMC firmware result byte:
+//   0    success
+//   0x82 firmware rejected (thermalmonitord holding SYSTEM mode)
+//   -1   IOKit call failed or key absent
+// NOTE: the generic SMCWriteKey ignores this byte, which is exactly why a
+// direct mode write "succeeds" yet doesn't stick in SYSTEM mode.
+static int writeFanModeRaw(int fanNum, int mode, io_connect_t conn)
+{
+    char keyStr[8];
+    fanModeKey(keyStr, fanNum, conn);
+    UInt32 key = _strtoul(keyStr, 4, 16);
+
+    SMCKeyData_keyInfo_t ki;
+    if (SMCGetKeyInfo(key, &ki, conn) != kIOReturnSuccess || ki.dataSize != 1)
+        return -1;
+
+    SMCKeyData_t in, out;
+    memset(&in, 0, sizeof(in));
+    memset(&out, 0, sizeof(out));
+    in.key = key;
+    in.data8 = SMC_CMD_WRITE_BYTES;
+    in.keyInfo.dataSize = 1;
+    in.bytes[0] = (UInt8)mode;
+    if (SMCCall(KERNEL_INDEX_SMC, &in, &out, conn) != kIOReturnSuccess)
+        return -1;
+    return out.result;
+}
+
+// Read the fan mode key, returning the raw byte (0/1/3) or -1 on failure.
+static int readFanModeRaw(int fanNum, io_connect_t conn)
+{
+    char key[8];
+    fanModeKey(key, fanNum, conn);
+
+    SMCVal_t val;
+    if (SMCReadKey(key, &val, conn) != kIOReturnSuccess || val.dataSize != 1)
+        return -1;
+    return val.bytes[0];
+}
+
+// Take manual control of a fan so F%dTg writes stick, at any temperature.
+//
+// A direct mode=1 write is enough from AUTO. From SYSTEM (mode 3) the firmware
+// either rejects the write (0x82) or accepts it but thermalmonitord reclaims it
+// within a polling cycle, so the fan never actually leaves system control. We
+// therefore VERIFY the mode actually stuck rather than trusting the write
+// result; if it did not, we set Ftst=1 to suppress thermalmonitord and retry
+// mode=1 until it holds (the daemon yields a few seconds after Ftst=1).
+//
+// Mechanism from agoodkind/macos-smc-fan (MIT).
+kern_return_t unlockFanManual(int fanNum, io_connect_t conn)
+{
+    // Phase 1: direct write, then confirm it took.
+    writeFanModeRaw(fanNum, 1, conn);
+    usleep(200000); // 0.2s: long enough for a reclaim to show up
+    if (readFanModeRaw(fanNum, conn) == 1)
+        return kIOReturnSuccess;
+
+    // Phase 2: thermalmonitord is holding system mode. Suppress it via Ftst,
+    // then retry mode=1 until it sticks.
+    if (ftstAvailable(conn))
+    {
+        writeFtst(1, conn);
+        usleep(500000); // 0.5s
+        for (int i = 0; i < 100; i++) // up to ~10s
+        {
+            writeFanModeRaw(fanNum, 1, conn);
+            usleep(100000); // 0.1s
+            if (readFanModeRaw(fanNum, conn) == 1)
+                return kIOReturnSuccess;
+        }
+    }
+
+    return kIOReturnError;
+}
+
 kern_return_t setFanMode(int fanNum, int mode, io_connect_t conn)
 {
     SMCVal_t val;
-    char key[5];
-    sprintf(key, "F%dMd", fanNum);
-    
+    char key[8];
+    fanModeKey(key, fanNum, conn);
+
     kern_return_t result = SMCReadKey(key, &val, conn);
     if (result != kIOReturnSuccess)
     {
-        // F{n}Md might not exist on some systems
+        // mode key might not exist on some systems
         return kIOReturnSuccess; // Not an error, just skip
     }
-    
+
     if (val.dataSize == 1)
     {
         val.bytes[0] = (UInt8)mode;
         sprintf(val.key, "%s", key);
         result = SMCWriteKey(val, conn);
     }
-    
+
     return result;
 }
 
@@ -290,10 +418,15 @@ kern_return_t setFanSpeed(int fanNum, int speed, io_connect_t conn)
 {
     SMCVal_t val;
     char key[5];
-    
-    // First, set fan mode to forced (1)
-    setFanMode(fanNum, 1, conn);
-    
+
+    // Take manual control. Direct mode=1 works from AUTO; if the firmware holds
+    // SYSTEM mode (0x82) it falls back to the Ftst force-test unlock.
+    if (unlockFanManual(fanNum, conn) != kIOReturnSuccess)
+    {
+        fprintf(stderr, "Error: could not take manual control of fan %d\n", fanNum);
+        return kIOReturnError;
+    }
+
     // Then set target speed using F{n}Tg
     sprintf(key, "F%dTg", fanNum);
     
@@ -332,8 +465,11 @@ kern_return_t setFanSpeed(int fanNum, int speed, io_connect_t conn)
 
 kern_return_t setFanAuto(int fanNum, io_connect_t conn)
 {
-    // Set fan mode back to automatic (0)
-    return setFanMode(fanNum, 0, conn);
+    // Hand control back to thermalmonitord, then clear any Ftst unlock.
+    kern_return_t result = setFanMode(fanNum, 0, conn);
+    if (ftstAvailable(conn))
+        writeFtst(0, conn);
+    return result;
 }
 
 void printFanInfo(io_connect_t conn)

--- a/tools/smc-helper/smc.c
+++ b/tools/smc-helper/smc.c
@@ -248,8 +248,7 @@ static int validFan(int fanNum, io_connect_t conn)
     int n = getFanCount(conn);
     if (n <= 0)
         return fanNum < 8; // SMC count unreadable: allow only a small sane range
-    return fanNum < n;
-}
+    return fanNum < n && fanNum < 10;
 
 float getFanSpeed(int fanNum, io_connect_t conn)
 {


### PR DESCRIPTION
## Problem

On Apple Silicon, fan control silently does nothing on some machines — the UI works and temps read fine, but setting a speed has no effect. Reported in #10 (M4).

## Root cause

`thermalmonitord` holds the fans in **system mode** (mode key == `3`) whenever it is managing thermals. A direct `mode=1` write is either:

- rejected by firmware with `0x82` (`SmcBadCommand`), or
- accepted but **silently reclaimed** within a polling cycle,

so the fan never actually leaves system control and the following `F%dTg` target write does nothing. `SMCWriteKey` discards the firmware result byte, so the helper can't even tell the mode write failed.

It only reproduces while the daemon is in system mode (cool/idle, or active mitigation). From plain `AUTO` a direct write works — which is why it looks intermittent.

## Fix

`setFanSpeed` now goes through a new `unlockFanManual`, which:

- probes the **mode-key casing** at runtime — `F%dMd` (Intel/M1–M4) vs `F%dmd` (M5) — instead of hardcoding `F%dMd`, and probes whether `Ftst` exists;
- writes `mode=1` and **verifies it actually stuck** (re-reads the mode) rather than trusting the discarded write result;
- if it did not stick, sets the `Ftst` force-test flag to suppress `thermalmonitord`, then retries `mode=1` until it holds (~10s timeout).

`setFanAuto` clears `Ftst` when handing control back.

## Testing

Verified on **MacBook Pro M4 Pro (Mac16,8) / macOS 26.4.1**:

- Before: from system mode, Manual set the UI to Manual but fans stayed parked at 0 RPM.
- After: control is acquired from system mode, fans obey, mode reads `MANUAL`.

Source-only change to `tools/smc-helper/smc.c`; rebuild with `make`.

## Attribution

The `Ftst` force-test unlock mechanism is adapted from the MIT-licensed research in [agoodkind/macos-smc-fan](https://github.com/agoodkind/macos-smc-fan).

Closes #10