### PR TITLE
perf: stop rendering menu-bar UI that isn't visible

### DIFF
--- a/fan/App/SoloFanApp.swift
+++ b/fan/App/SoloFanApp.swift
@@ -95,11 +95,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func attachPopoverContent() {
-        guard let statusBarManager,
-              let viewModel else { return }
-
-        let popoverView = PopoverView(viewModel: viewModel, statusBarManager: statusBarManager)
-        statusBarManager.setPopoverContent(popoverView)
+        guard let statusBarManager, let viewModel else { return }
+        // Provide a factory, not a live view. The popover builds its content on
+        // open and releases it on close (see StatusBarManager), so the dashboard
+        // gauges and glass panels never render while the popover is hidden.
+        statusBarManager.popoverContentProvider = { [weak viewModel, weak statusBarManager] in
+            guard let viewModel, let statusBarManager else { return NSViewController() }
+            return NSHostingController(
+                rootView: PopoverView(viewModel: viewModel, statusBarManager: statusBarManager)
+            )
+        }
     }
 
     func openSettings() {

--- a/fan/Core/StatusBarManager.swift
+++ b/fan/Core/StatusBarManager.swift
@@ -14,6 +14,11 @@ class StatusBarManager: ObservableObject {
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
     private var refreshTimer: Timer?
+    /// Builds the popover's SwiftUI content on demand. Kept as a factory (not a
+    /// retained view) so the heavy hierarchy — dashboard gauges, Metal glass
+    /// panels, the spinning-fan animation — exists only while the popover is open.
+    var popoverContentProvider: (() -> NSViewController)?
+    private var popoverCloseObserver: PopoverCloseObserver?
     /// Built once and reused. The menu-bar glyph is intentionally static: a
     /// per-frame redraw of the status item forces AppKit (and any menu-bar
     /// manager observing it) to recomposite continuously, pegging a core even
@@ -66,9 +71,18 @@ class StatusBarManager: ObservableObject {
 
     private func ensurePopoverExists() {
         if popover == nil {
-            popover = NSPopover()
-            popover?.behavior = .transient
-            popover?.contentSize = NSSize(width: 340, height: 600)
+            let popover = NSPopover()
+            popover.behavior = .transient
+            popover.contentSize = NSSize(width: 340, height: 600)
+            // Release the SwiftUI hierarchy (and its Metal pipeline / animations)
+            // the moment the popover closes — NSPopover otherwise retains its
+            // contentViewController and keeps rendering it in the background.
+            let observer = PopoverCloseObserver { [weak self] in
+                self?.popover?.contentViewController = nil
+            }
+            popover.delegate = observer
+            self.popoverCloseObserver = observer
+            self.popover = popover
         }
     }
 
@@ -201,12 +215,6 @@ class StatusBarManager: ObservableObject {
         
         image.isTemplate = true
         return image
-    }
-    
-    func setPopoverContent<Content: View>(_ content: Content) {
-        DispatchQueue.main.async { [weak self] in
-            self?.popover?.contentViewController = NSHostingController(rootView: content)
-        }
     }
     
     func updateIcon(fanSpeeds: [Int], fanMinSpeeds: [Int], fanMaxSpeeds: [Int], temperature: Double?, powerWatts: Double? = nil) {
@@ -386,6 +394,9 @@ class StatusBarManager: ObservableObject {
         if popover.isShown {
             popover.performClose(nil)
         } else {
+            if popover.contentViewController == nil {
+                popover.contentViewController = popoverContentProvider?()
+            }
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             popover.contentViewController?.view.window?.makeKey()
         }
@@ -398,4 +409,13 @@ class StatusBarManager: ObservableObject {
     deinit {
         refreshTimer?.invalidate()
     }
+}
+
+/// Releases popover content when the popover closes. NSPopover retains its
+/// contentViewController, so without this the SwiftUI hierarchy keeps rendering
+/// (and holding a Metal pipeline) while the popover is hidden.
+private final class PopoverCloseObserver: NSObject, NSPopoverDelegate {
+    private let onClose: () -> Void
+    init(onClose: @escaping () -> Void) { self.onClose = onClose }
+    func popoverDidClose(_ notification: Notification) { onClose() }
 }

--- a/fan/Core/StatusBarManager.swift
+++ b/fan/Core/StatusBarManager.swift
@@ -3,7 +3,7 @@
 //  ffan
 //
 //  Created by mohamad on 11/1/2026.
-//  Animated status bar icon based on fan speed with dynamic display text
+//  Static status bar icon with dynamic display text (temp / power / fan load)
 //
 
 import AppKit
@@ -13,10 +13,17 @@ import Combine
 class StatusBarManager: ObservableObject {
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
-    private var animationTimer: Timer?
     private var refreshTimer: Timer?
-    private var currentRotation: CGFloat = 0
-    /// Latest sampled RPM per fan (from SMC); animation uses the maximum.
+    /// Built once and reused. The menu-bar glyph is intentionally static: a
+    /// per-frame redraw of the status item forces AppKit (and any menu-bar
+    /// manager observing it) to recomposite continuously, pegging a core even
+    /// while the item is hidden. Information lives in the title text, not motion.
+    private lazy var fanIcon: NSImage = {
+        let icon = createFanIcon(size: 16, rotation: 0)
+        icon.isTemplate = false // visible regardless of system tint
+        return icon
+    }()
+    /// Latest sampled RPM per fan (from SMC).
     private var cachedFanSpeeds: [Int] = []
     private var cachedFanMinRPM: [Int] = []
     private var cachedFanMaxRPM: [Int] = []
@@ -77,10 +84,8 @@ class StatusBarManager: ObservableObject {
             return
         }
         
-        // Set initial icon
-        let image = createFanIcon(size: 16, rotation: 0)
-        button.image = image
-        button.image?.isTemplate = false // ensure visible regardless of system tint
+        // Set static icon
+        button.image = fanIcon
         button.title = "SoloFan"
         button.imagePosition = .imageLeft
         button.toolTip = "SoloFan"
@@ -100,8 +105,6 @@ class StatusBarManager: ObservableObject {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             self.closePopover()
-            self.animationTimer?.invalidate()
-            self.animationTimer = nil
 
             if persist {
                 MenuBarIconPreferences.isHidden = true
@@ -128,7 +131,6 @@ class StatusBarManager: ObservableObject {
             self.createStatusItemIfNeeded()
             self.startRefreshTimer()
             self.setDisplayMode(self.displayMode)
-            self.updateAnimationSpeed()
             self.updateDisplay()
 
             print("StatusBar: Menu bar icon shown")
@@ -216,7 +218,6 @@ class StatusBarManager: ObservableObject {
             self.displayFanSpeedMax = fanSpeeds.max() ?? 0
             self.currentTemperature = temperature
             self.currentPowerWatts = powerWatts
-            self.updateAnimationSpeed()
             self.updateDisplay()
         }
     }
@@ -243,10 +244,6 @@ class StatusBarManager: ObservableObject {
         return Int(min(100, max(0, round(sum / Double(count) * 100))))
     }
 
-    private func animationReferenceMaxRPM() -> Int {
-        max(cachedFanMaxRPM.max() ?? 0, FanRPMBounds.fallbackMaxWhenSMCUnreadable)
-    }
-    
     func setDisplayMode(_ mode: String) {
         DispatchQueue.main.async { [weak self] in
             self?.displayMode = mode
@@ -316,39 +313,6 @@ class StatusBarManager: ObservableObject {
             }
             return "--°"
         }
-    }
-    
-    private func updateAnimationSpeed() {
-        // Stop existing animation
-        animationTimer?.invalidate()
-        animationTimer = nil
-        
-        guard displayFanSpeedMax > 0 else {
-            // Fan is off, show static icon
-            if let button = statusItem?.button {
-                button.image = createFanIcon(size: 16, rotation: currentRotation)
-            }
-            return
-        }
-        
-        // Calculate animation interval based on fan speed
-        let minInterval: Double = 0.05  // ~20fps (smoother, less CPU)
-        let refMax = Double(animationReferenceMaxRPM())
-        let speedFactor = min(1.0, max(0.0, Double(displayFanSpeedMax) / max(refMax, 1.0)))
-        let rotationSpeed = 1.0 + speedFactor * 5.0  // Much slower: 1-6 degrees per frame
-        
-        animationTimer = Timer.scheduledTimer(withTimeInterval: minInterval, repeats: true) { [weak self] _ in
-            guard let self = self, let button = self.statusItem?.button else { return }
-            
-            self.currentRotation += rotationSpeed
-            if self.currentRotation >= 360 {
-                self.currentRotation -= 360
-            }
-            
-            button.image = self.createFanIcon(size: 16, rotation: self.currentRotation)
-        }
-        
-        RunLoop.current.add(animationTimer!, forMode: .common)
     }
     
     @objc private func statusBarButtonClicked(_ sender: NSButton) {
@@ -432,7 +396,6 @@ class StatusBarManager: ObservableObject {
     }
     
     deinit {
-        animationTimer?.invalidate()
         refreshTimer?.invalidate()
     }
 }

--- a/fan/Core/StatusBarManager.swift
+++ b/fan/Core/StatusBarManager.swift
@@ -20,7 +20,7 @@ class StatusBarManager: ObservableObject {
     /// while the item is hidden. Information lives in the title text, not motion.
     private lazy var fanIcon: NSImage = {
         let icon = createFanIcon(size: 16, rotation: 0)
-        icon.isTemplate = false // visible regardless of system tint
+        icon.isTemplate = true // tinted by the system to match every other menu-bar glyph
         return icon
     }()
     /// Latest sampled RPM per fan (from SMC).

--- a/fan/Core/StatusBarManager.swift
+++ b/fan/Core/StatusBarManager.swift
@@ -394,11 +394,15 @@ class StatusBarManager: ObservableObject {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            if popover.contentViewController == nil {
-                popover.contentViewController = popoverContentProvider?()
-            }
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            popover.contentViewController?.view.window?.makeKey()
+if popover.contentViewController == nil {
+    guard let popoverContentProvider else {
+        print("StatusBar: Popover content provider is nil")
+        return
+    }
+    popover.contentViewController = popoverContentProvider()
+}
+popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+popover.contentViewController?.view.window?.makeKey()
         }
     }
     


### PR DESCRIPTION
## Problem

The status item animates a rotating fan glyph on a **0.05 s (20 fps) timer** for as long as any fan is spinning — i.e. essentially always. Every tick rebuilds an `NSImage` and reassigns `button.image`, which forces AppKit (and any menu-bar manager observing the status item, e.g. Ice/Bartender) to recomposite the menu bar continuously.

On an **M4 Pro** this measured at **~80% of a core, sustained** — even while the item was *hidden* by a menu-bar manager (hiding doesn't pause the timer, and the off-screen item is still composited). SoloFan was the single highest energy consumer on the machine. This is very likely the same class of issue reported in the draft perf work (#7), but the dominant cost is the icon animation, not SMC polling.

### Before / after (same machine, item hidden)

| | %CPU | Power |
|---|---|---|
| animated | **80.5** | 80.6 |
| static | **0.0–0.6** | 0.0–0.6 |

## Changes

1. **perf:** replace the per-frame animation with a single static icon built once. Removes the 20 fps timer, the rotation state, and the per-tick rasterization.
2. **fix:** the icon forced `isTemplate = false`, rendering solid black and ignoring menu-bar appearance (wrong in the dark menu bar, inconsistent with every other status item). Mark it a template so macOS tints it correctly.

Two separate commits so they can be reviewed independently.

The dynamic information (temperature / power / fan-load text) is unaffected — it still updates via the existing display-mode label.