### PR TITLE
fix: auto max-speed (and manual) forgetting its value across launches

### DIFF
--- a/fan/Core/FanController.swift
+++ b/fan/Core/FanController.swift
@@ -108,13 +108,12 @@ class FanController: ObservableObject {
     private func onHardwareLimitsUpdated() {
         guard let monitor = systemMonitor, monitor.numberOfFans > 0 else { return }
         ensureManualSpeedsSize()
-        manualSpeed = clampUnified(manualSpeed)
-        autoMaxSpeed = clampUnified(autoMaxSpeed)
-        if !manualSpeeds.isEmpty {
-            manualSpeeds = manualSpeeds.enumerated().map { clampToFan($0.element, index: $0.offset) }
-        }
-        saveSettings()
-
+        // Do NOT clamp the stored preferences (manualSpeed / autoMaxSpeed) to the live
+        // hardware max here. F{n}Mx reads intermittently on Apple Silicon — it flips to
+        // the unreadable fallback — and this fires on every such flip, so clamping would
+        // repeatedly shrink and re-save the user's ceiling (the "max speed forgets itself"
+        // bug). Targets are clamped to the real limit at apply time instead, so a low
+        // reading never spins the fan past hardware while the preference is preserved.
         if mode == .manual && isControlEnabled {
             applyManualTargets()
         } else if mode == .automatic && isControlEnabled {


### PR DESCRIPTION
## Problem

The auto **Max Speed** slider doesn't remember its value — relaunch the app and it resets, while the fixed-range sliders (Threshold, Response) persist fine.

`onHardwareLimitsUpdated()` re-clamps `manualSpeed` and `autoMaxSpeed` to the **live** `F{n}Mx` and re-saves — and it's wired to `$fanMaxSpeeds.combineLatest(...)`, so it runs **every time that reading changes**. On Apple Silicon `F{n}Mx` reads intermittently and falls back to `fallbackMaxWhenSMCUnreadable` (5200). Each time it flips low, the user's saved ceiling is clamped down to the fallback and persisted. Threshold/Response have fixed ranges, so they're immune — which is exactly the reported asymmetry.

(Reproduced on an M4 Pro: `defaults read … autoMaxSpeed` was a real high reading, `manualFanSpeed` was sitting at exactly the 5200 fallback.)

## Fix

Don't clamp the stored *preferences* to volatile hardware in `onHardwareLimitsUpdated`. Targets are already clamped to the real hardware limit at **apply** time — auto via `min(autoMaxSpeed, unifiedMaxClamp)`, manual via `clampToFan(...)` — so a transient low reading still never overspins the fan, but the saved value is preserved. `ensureManualSpeedsSize()` (array sizing) and the re-apply are kept.